### PR TITLE
Updates build-gh-pages.yml to use supported python 3.13

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.12.8
+    - name: Set up Python 3.13
       uses: actions/setup-python@v1
       with:
-        python-version: 3.12.8
+        python-version: 3.13
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
The build action responded with a error: Error: Version 3.12.8 with arch x64 not found.

The support seems to have changed from 3.12.8 to 3.12.9. This patch upgrades to 3.13 and leaves off the patch number of the version.